### PR TITLE
Fix correct_guess handler

### DIFF
--- a/src/pages/Game.vue
+++ b/src/pages/Game.vue
@@ -147,7 +147,7 @@ onMounted(() => {
   socket.value.emit('join_lobby', { name: playerName.value, character: character.value });
 
 socket.value.on('correct_guess', (data) => {
-  isCurrentDrawer.value = falsex
+  isCurrentDrawer.value = false;
 });
 socket.value.on('your_word', (data) => {
   currentWord.value = data.word;


### PR DESCRIPTION
## Summary
- fix typo in `correct_guess` handler to correctly reset drawer state

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684151eb0ac48330bc766934794b74b6